### PR TITLE
ViewportPastingDecorator: use pageYOffset instead of scrollY

### DIFF
--- a/src/main/java/pazone/ashot/ViewportPastingDecorator.java
+++ b/src/main/java/pazone/ashot/ViewportPastingDecorator.java
@@ -75,7 +75,7 @@ public class ViewportPastingDecorator extends ShootingDecorator {
     }
 
     protected int getCurrentScrollY(JavascriptExecutor js) {
-        return ((Number) js.executeScript("var scrY = window.scrollY;"
+        return ((Number) js.executeScript("var scrY = window.pageYOffset;"
         		+ "if(scrY){return scrY;} else {return 0;}")).intValue();
     }
 


### PR DESCRIPTION
to improve browsers compatibility; especially in IE9-, we now can use VIewportPasting() strategy, hopefully it might fix #110
