### PR TITLE
remove Oracle JDK7 test from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
  - openjdk7
- - oraclejdk7
  - oraclejdk8
 notifications:
  email: false


### PR DESCRIPTION
because Travis CI already removed their Oracle JDK7 support.
I thought it is already outdated and just removing it is fine.