### PR TITLE
Increment minimal required JDK to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,8 +96,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Java 7 reached EOL on April 2015: https://www.java.com/en/download/faq/java_7.xml.
Also Selenium 3.X requires Java 8+: https://raw.githubusercontent.com/SeleniumHQ/selenium/master/java/CHANGELOG