### PR TITLE
Bump Hamcrest from 1.3 to 2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <version>1.3</version>
+            <artifactId>hamcrest</artifactId>
+            <version>2.1</version>
         </dependency>
 
         <!--test-->
@@ -59,12 +59,6 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
https://github.com/hamcrest/JavaHamcrest/releases/tag/v2.1:
"After a long hiatus without releases, this version simplifies the packaging of
Hamcrest into a single jar: hamcrest-2.1.jar. Other big changes include
Java 9 module compatibility, along with numerous other improvements and bug
fixes."