### PR TITLE
Use shields.io for release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ aShot
 =====
 
 
-[![release](http://github-release-version.herokuapp.com/github/yandex-qatools/ashot/release.svg?style=flat)](https://github.com/yandex-qatools/ashot/releases/latest) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/ru.yandex.qatools.ashot/ashot/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/ru.yandex.qatools.ashot/ashot)
+[![release](https://img.shields.io/github/v/release/pazone/ashot.svg)](https://github.com/pazone/ashot/releases/latest) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/ru.yandex.qatools.ashot/ashot/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/ru.yandex.qatools.ashot/ashot)
 
 
 WebDriver Screenshot utility


### PR DESCRIPTION
The badge is not rendered:
<img width="237" alt="badge-issue" src="https://user-images.githubusercontent.com/5081226/65837572-ac7f3100-e301-11e9-862d-66e3c7acb099.png">

The application is not responsive:
<img width="492" alt="app-error" src="https://user-images.githubusercontent.com/5081226/65837600-14357c00-e302-11e9-8211-0c58e9293ef2.png">

I propose to switch to https://shields.io/