### PR TITLE
Optimize extraction of page dimensions

### DIFF
--- a/src/main/java/pazone/ashot/PageDimensions.java
+++ b/src/main/java/pazone/ashot/PageDimensions.java
@@ -1,0 +1,25 @@
+package pazone.ashot;
+
+public final class PageDimensions {
+    private final int pageHeight;
+    private final int viewportWidth;
+    private final int viewportHeight;
+
+    public PageDimensions(int pageHeight, int viewportWidth, int viewportHeight) {
+        this.pageHeight = pageHeight;
+        this.viewportHeight = viewportHeight;
+        this.viewportWidth = viewportWidth;
+    }
+
+    public int getPageHeight() {
+        return pageHeight;
+    }
+
+    public int getViewportWidth() {
+        return viewportWidth;
+    }
+
+    public int getViewportHeight() {
+        return viewportHeight;
+    }
+}

--- a/src/main/java/pazone/ashot/util/InnerScript.java
+++ b/src/main/java/pazone/ashot/util/InnerScript.java
@@ -14,10 +14,6 @@ import static java.lang.Thread.currentThread;
 
 public final class InnerScript {
 
-    public static final String PAGE_HEIGHT_JS = "js/page_height.js";
-    public static final String VIEWPORT_HEIGHT_JS = "js/viewport_height.js";
-    public static final String VIEWPORT_WIDTH_JS = "js/viewport_width.js";
-
     private InnerScript() {
         throw new UnsupportedOperationException();
     }

--- a/src/main/resources/js/page_dimensions.js
+++ b/src/main/resources/js/page_dimensions.js
@@ -1,0 +1,7 @@
+var body = document.body;
+var documentElement = document.documentElement;
+var pageHeight = Math.max(body.scrollHeight, body.offsetHeight, documentElement.clientHeight,
+    documentElement.scrollHeight, documentElement.offsetHeight);
+var viewportHeight = window.innerHeight || documentElement.clientHeight|| body.clientHeight;
+var viewportWidth = window.innerWidth || documentElement.clientWidth || body.clientWidth;
+return {pageHeight, viewportHeight, viewportWidth}

--- a/src/main/resources/js/page_height.js
+++ b/src/main/resources/js/page_height.js
@@ -1,2 +1,0 @@
-return Math.max(document.body.scrollHeight, document.body.offsetHeight,
-    document.documentElement.clientHeight, document.documentElement.scrollHeight, document.documentElement.offsetHeight);

--- a/src/main/resources/js/viewport_height.js
+++ b/src/main/resources/js/viewport_height.js
@@ -1,1 +1,0 @@
-return window.innerHeight || document.documentElement.clientHeight || document.getElementsByTagName('body')[0].clientHeight;

--- a/src/main/resources/js/viewport_width.js
+++ b/src/main/resources/js/viewport_width.js
@@ -1,1 +1,0 @@
-return window.innerWidth || document.documentElement.clientWidth || document.getElementsByTagName('body')[0].clientWidth;

--- a/src/test/java/pazone/ashot/VerticalPastingShootingStrategyTest.java
+++ b/src/test/java/pazone/ashot/VerticalPastingShootingStrategyTest.java
@@ -140,18 +140,8 @@ class VerticalPastingShootingStrategyTest {
         }
 
         @Override
-        public int getFullHeight(WebDriver driver) {
-            return DEFAULT_PAGE_HEIGHT;
-        }
-
-        @Override
-        public int getFullWidth(WebDriver driver) {
-            return PAGE_WIDTH;
-        }
-
-        @Override
-        public int getWindowHeight(WebDriver driver) {
-            return VIEWPORT_HEIGHT;
+        protected PageDimensions getPageDimensions(WebDriver driver) {
+            return new PageDimensions(DEFAULT_PAGE_HEIGHT, PAGE_WIDTH, VIEWPORT_HEIGHT);
         }
 
         @Override


### PR DESCRIPTION
The previous implementation executed JS 3 times to extract page height, viewport width and viewport height. This change joins the scripts and introduces the model with 3 page dimensions, having this JS is executed only 1 time.