### PR TITLE
Specify version of maven-javadoc-plugin to avoid build warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.1.1</version>
                 <configuration>
                     <additionalOptions>
                         <additionalOption>-Xdoclint:none</additionalOption>


### PR DESCRIPTION
Fixes build warnings like:
```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.github.pazone:ashot:jar:1.6.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-javadoc-plugin is missing. @ line 107, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```
