### PR TITLE
Bump Selenium from 2.53.0 to 3.141.59

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-remote-driver</artifactId>
-            <version>2.53.0</version>
+            <version>3.141.59</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -58,6 +58,12 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.5.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.10.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Selenium `2.53.0` was released more than 4 years ago, it's time to upgrade the dependency