### PR TITLE
Fix WebDriver coordinate calculation for PhantomJS

### DIFF
--- a/src/main/java/pazone/ashot/coordinates/WebDriverCoordsProvider.java
+++ b/src/main/java/pazone/ashot/coordinates/WebDriverCoordsProvider.java
@@ -1,8 +1,10 @@
 package pazone.ashot.coordinates;
 
-import org.openqa.selenium.Rectangle;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.Point;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+
 
 /**
  * @author <a href="pazone@yandex-team.ru">Pavel Zorin</a>
@@ -10,11 +12,12 @@ import org.openqa.selenium.WebElement;
 public class WebDriverCoordsProvider extends CoordsProvider {
     @Override
     public Coords ofElement(WebDriver driver, WebElement element) {
-        Rectangle rect = element.getRect();
+        Point point = element.getLocation();
+        Dimension dimension = element.getSize();
         return new Coords(
-                rect.getX(),
-                rect.getY(),
-                rect.getWidth(),
-                rect.getHeight());
+                point.getX(),
+                point.getY(),
+                dimension.getWidth(),
+                dimension.getHeight());
     }
 }

--- a/src/main/java/pazone/ashot/coordinates/WebDriverCoordsProvider.java
+++ b/src/main/java/pazone/ashot/coordinates/WebDriverCoordsProvider.java
@@ -9,9 +9,11 @@ import org.openqa.selenium.WebElement;
 /**
  * @author <a href="pazone@yandex-team.ru">Pavel Zorin</a>
  */
+
 public class WebDriverCoordsProvider extends CoordsProvider {
     @Override
     public Coords ofElement(WebDriver driver, WebElement element) {
+        // Keep Point/Dimension as opposed to Rectangle because browsers like PhantomJS do not like the latter
         Point point = element.getLocation();
         Dimension dimension = element.getSize();
         return new Coords(

--- a/src/main/java/pazone/ashot/coordinates/WebDriverCoordsProvider.java
+++ b/src/main/java/pazone/ashot/coordinates/WebDriverCoordsProvider.java
@@ -5,11 +5,9 @@ import org.openqa.selenium.Point;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
-
 /**
  * @author <a href="pazone@yandex-team.ru">Pavel Zorin</a>
  */
-
 public class WebDriverCoordsProvider extends CoordsProvider {
     @Override
     public Coords ofElement(WebDriver driver, WebElement element) {

--- a/src/test/java/pazone/ashot/coordinates/WebDriverCoordsProviderTest.java
+++ b/src/test/java/pazone/ashot/coordinates/WebDriverCoordsProviderTest.java
@@ -1,14 +1,14 @@
 package pazone.ashot.coordinates;
 
-import org.junit.jupiter.api.Test;
-import org.openqa.selenium.Dimension;
-import org.openqa.selenium.Point;
-import org.openqa.selenium.WebElement;
-
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.Point;
+import org.openqa.selenium.WebElement;
 
 class WebDriverCoordsProviderTest {
     private WebDriverCoordsProvider webDriverCoordsProvider = new WebDriverCoordsProvider();
@@ -21,7 +21,7 @@ class WebDriverCoordsProviderTest {
         int height = 3;
         int width = 4;
         when(element.getLocation()).thenReturn(new Point(x, y));
-        when(element.getSize()).thenReturn(new Dimension(4, 3));
+        when(element.getSize()).thenReturn(new Dimension(width, height));
         Coords coords = webDriverCoordsProvider.ofElement(null, element);
         assertAll(
                 () -> assertEquals(x, coords.x),

--- a/src/test/java/pazone/ashot/coordinates/WebDriverCoordsProviderTest.java
+++ b/src/test/java/pazone/ashot/coordinates/WebDriverCoordsProviderTest.java
@@ -1,13 +1,14 @@
 package pazone.ashot.coordinates;
 
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.Point;
+import org.openqa.selenium.WebElement;
+
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import org.junit.jupiter.api.Test;
-import org.openqa.selenium.Rectangle;
-import org.openqa.selenium.WebElement;
 
 class WebDriverCoordsProviderTest {
     private WebDriverCoordsProvider webDriverCoordsProvider = new WebDriverCoordsProvider();
@@ -19,7 +20,8 @@ class WebDriverCoordsProviderTest {
         int y = 2;
         int height = 3;
         int width = 4;
-        when(element.getRect()).thenReturn(new Rectangle(x, y, height, width));
+        when(element.getLocation()).thenReturn(new Point(x, y));
+        when(element.getSize()).thenReturn(new Dimension(4, 3));
         Coords coords = webDriverCoordsProvider.ofElement(null, element);
         assertAll(
                 () -> assertEquals(x, coords.x),


### PR DESCRIPTION
This basically reverts @1c80c9b, but keeps the unit test intact.

Fixes #203.