### PR TITLE
Remove invalid input parameter of Maven Checkstyle plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,6 @@
                         <version>3.2.2</version>
                         <configuration>
                             <configLocation>config/checkstyle/checkstyle.xml</configLocation>
-                            <encoding>UTF-8</encoding>
                             <consoleOutput>true</consoleOutput>
                             <failsOnError>true</failsOnError>
                             <includeTestSourceDirectory>true</includeTestSourceDirectory>


### PR DESCRIPTION
Maven Checkstyle plugin warnings:

> [WARNING] Parameter 'encoding' is unknown for plugin 'maven-checkstyle-plugin:3.2.2:check (validate)'
> [WARNING] Parameter 'encoding' is unknown for plugin 'maven-checkstyle-plugin:3.2.2:check (validate)'

The valid parameter name is `<inputEncoding>` however it's optional and its default value is ${project.build.sourceEncoding}, which is also equal to UTF-8 for this project. So there is no reason to keep the parameter.