### PR TITLE
Release workflow to GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,3 @@ jobs:
 
     - name: Tests
       run: ./mvnw clean test
-
-    - name: deploy snapshot
-      if: github.ref == 'refs/heads/master' && matrix.java == '8'
-      env:
-        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        OSS_PWD: ${{ secrets.OSS_PWD }}
-        OSS_USER: ${{ secrets.OSS_USER }}
-      run: |
-        cp .ci.settings.xml ~/.m2/settings.xml
-        ./mvnw -Dgpg.passphrase=$GPG_PASSPHRASE -DskipTests deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release and Deploy
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Extract Release Version
+        run: |
+          RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "Release version: $RELEASE_VERSION"
+        id: release_version
+
+      - name: Verify Tag and Release
+        run: |
+          TAG_VERSION=$(echo "${GITHUB_REF#refs/tags/}")
+          if [ "$TAG_VERSION" != "${{ steps.release_version.outputs.version }}" ]; then
+            echo "Error: Tag version ($TAG_VERSION) does not match release version ($RELEASE_VERSION)"
+            exit 1
+          fi
+          echo "Tag version and release version match: $RELEASE_VERSION"      
+
+      - name: Release with Maven
+        run: ./mvnw --batch-mode release:clean release:prepare release:perform
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          MAVEN_USERNAME: ${{ secrets.GITHUB_ACTOR }}
+          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'zulu'
+        java-version: ${{ matrix.java }}
+        cache: 'maven'
+
+    - name: deploy snapshot (sonatype)
+      if: github.ref == 'refs/heads/master' && matrix.java == '8'
+      env:
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        OSS_PWD: ${{ secrets.OSS_PWD }}
+        OSS_USER: ${{ secrets.OSS_USER }}
+      run: |
+        cp .ci.settings.xml ~/.m2/settings.xml
+        ./mvnw -Dgpg.passphrase=$GPG_PASSPHRASE -DskipTests deploy
+
+    - name: deploy snapshot (github packages)
+      if: github.ref == 'refs/heads/master' && matrix.java == '8'
+      env:
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        MAVEN_USERNAME: ${{ secrets.GITHUB_ACTOR }}
+        MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cp .ci.settings.xml ~/.m2/settings.xml
+        ./mvnw -Dgpg.passphrase=$GPG_PASSPHRASE -DskipTests deploy

--- a/pom.xml
+++ b/pom.xml
@@ -111,14 +111,21 @@
         </plugins>
     </build>
 
+<!--    <distributionManagement>-->
+<!--        <snapshotRepository>-->
+<!--            <id>ossrh</id>-->
+<!--            <url>https://oss.sonatype.org/content/repositories/snapshots</url>-->
+<!--        </snapshotRepository>-->
+<!--        <repository>-->
+<!--            <id>ossrh</id>-->
+<!--            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>-->
+<!--        </repository>-->
+<!--    </distributionManagement>-->
+
     <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/pazone/ashot</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
I've added two more workflows, so now we've got three in total:

* ci: builds unit tests for pull requests and pushes them to the `master` branch.
* deploy:  handles snapshot deployment to Nexus and Github Packages.
* release: kicks off when a tag is created with a corresponding version. It utilizes the maven-release-plugin to publish the release artifact to Github Packages. After completing the release, it updates the `master` branch with a new snapshot version.